### PR TITLE
connection: implement the error trait

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,6 +20,8 @@
 
 use std::collections::VecDeque;
 use std::env;
+use std::error;
+use std::fmt;
 use std::net::{TcpStream,ToSocketAddrs};
 use std::io;
 use std::io::{Read,Write};
@@ -106,6 +108,33 @@ impl From<string::FromUtf8Error> for Error {
 impl From<ParseIntError> for Error {
     fn from(_x: ParseIntError) -> Self {
         Error::AuthFailed
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Disconnected              => write!(f, "disconnected"),
+            Error::IOError(ref ioerr)        => write!(f, "i/o error: {}", ioerr),
+            Error::DemarshalError(ref dmerr) => write!(f, "demarshall error: {}", dmerr),
+            Error::AddressError(ref addrerr) => write!(f, "address error: {:?}", addrerr),
+            Error::BadData                   => write!(f, "bad data"),
+            Error::AuthFailed                => write!(f, "authentication failed"),
+            Error::NoEnvironment             => write!(f, "no environment"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "D-Bus error"
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::IOError(ref ioerr) => Some(ioerr),
+            _                         => None,
+        }
     }
 }
 

--- a/src/demarshal.rs
+++ b/src/demarshal.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::collections::HashMap;
 use std::mem::transmute;
 
@@ -11,6 +12,21 @@ pub enum DemarshalError {
     BadSignature,
     ElementTooBig,
     MismatchedParens,
+}
+
+impl fmt::Display for DemarshalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            DemarshalError::MessageTooShort  => "message too short",
+            DemarshalError::CorruptedMessage => "corrupted message",
+            DemarshalError::BadUTF8          => "bad utf-8",
+            DemarshalError::BadSignature     => "bad signature",
+            DemarshalError::ElementTooBig    => "element too big",
+            DemarshalError::MismatchedParens => "mismatched parens",
+        };
+
+        write!(f, "{}", msg)
+    }
 }
 
 pub fn get_alignment(sig: char) -> usize {


### PR DESCRIPTION
---

I tried implementing `fmt::Display` for `ServerAddressError`, but apparently type aliases can't have impls for traits outside the crate.
