### PR TITLE
message: derive MessageType from Eq

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -7,7 +7,7 @@ use dbus_serialize::types::{Path,Variant,Value,BasicValue,Signature};
 use marshal::{Marshal,pad_to_multiple};
 use demarshal::{demarshal,DemarshalError};
 
-#[derive(Debug,Default,PartialEq)]
+#[derive(Debug,Default,PartialEq,Eq)]
 pub struct MessageType(pub u8);
 pub const MESSAGE_TYPE_INVALID : MessageType        = MessageType(0);
 pub const MESSAGE_TYPE_METHOD_CALL : MessageType    = MessageType(1);


### PR DESCRIPTION
New Rust is warning about using MessageType values in `match` blocks:

```
warning: to use a constant of type
`connection::dbus_bytestream::message::MessageType` in a pattern,
`connection::dbus_bytestream::message::MessageType` must be
annotated with `#[derive(PartialEq, Eq)]`,
#[warn(illegal_struct_or_enum_constant_pattern)] on by default
```
